### PR TITLE
CH2 bug in websocket_client.html fixed

### DIFF
--- a/ch2-websocket-api/websocket_client.html
+++ b/ch2-websocket-api/websocket_client.html
@@ -51,6 +51,7 @@ The Definitive Guide to HTML5 WebSocket
 
             ws.onmessage = function(evt) {
                 log("MESSAGE RECEIVED: " + evt.data);
+                ws.close();
             }
         }
 
@@ -72,7 +73,6 @@ The Definitive Guide to HTML5 WebSocket
         function sendMessage(msg) {
             ws.send(msg);
             log("MESSAGE SENT");
-            ws.close();
         }
 
         // The window.addEventListener triggers when the web page is loaded


### PR DESCRIPTION
CH2 bug in websocket_client.html fixed where websocket is closed after sending message without receiving it

Earlier output was-
CONNECTED
MESSAGE SENT
DISCONNECTED

Now output is-
CONNECTED
MESSAGE SENT
MESSAGE RECEIVED: Hello WebSocket!
DISCONNECTED